### PR TITLE
Fix/microphone permission

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,8 +53,6 @@
 <string>This app needs photos to update profile picture</string>
 <key>NSCameraUsageDescription</key>
 <string>This app needs camera to update profile picture</string>
-<key>NSMicrophoneUsageDescription</key>
-<string>This app needs microphone to record profile picture</string>
 <key>LSApplicationQueriesSchemes</key>
 <array>
   <string>https</string>


### PR DESCRIPTION
This PR removes the key in info.plist that says the microphone is used by the app.

Closes #66 