### PR TITLE
fix: gives the summary button a color that draws more user attention

### DIFF
--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -537,7 +537,7 @@ class _ThisGraphHeadingWidget extends StatelessWidget {
                   width: 40,
                   height: 40,
                   decoration: BoxDecoration(
-                    color: AppColors.color8BA1BE.withOpacity(0.2),
+                    color: AppColors.colorE6007A,
                     borderRadius: BorderRadius.circular(12),
                   ),
                   padding: const EdgeInsets.all(10),


### PR DESCRIPTION
This PR fixes the summary button fadding by giving a color that draws more user attention.

Closes #120 

![Captura de tela 2022-03-11 095330](https://user-images.githubusercontent.com/38893955/157870477-38aa8010-8881-4265-805e-755eabf835c8.png)

