### PR TITLE
Fix/UI fixes

### DIFF
--- a/lib/common/navigation/coordinator.dart
+++ b/lib/common/navigation/coordinator.dart
@@ -114,12 +114,12 @@ abstract class Coordinator {
     _navigationKey.currentState?.pushNamed(Routes.notifDetailsScreen);
   }
 
-  static void goToMarketDetailsScreen({
+  static void goToBalanceCoinPreviewScreen({
     required AssetEntity asset,
     required BalanceCubit balanceCubit,
   }) {
     _navigationKey.currentState?.pushNamed(
-      Routes.marketDetailsScreen,
+      Routes.balanceCoinPreviewScreen,
       arguments: {
         'asset': asset,
         'balanceCubit': balanceCubit,

--- a/lib/common/navigation/coordinator.dart
+++ b/lib/common/navigation/coordinator.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/navigation/routes.dart';
-import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/utils/enums.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/screens/market_token_selection_screen.dart';
@@ -78,7 +77,6 @@ abstract class Coordinator {
 
   static void goToCoinTradeScreen({
     required BalanceCubit balanceCubit,
-    required OrderbookCubit orderbookCubit,
     required AssetEntity baseToken,
     required AssetEntity quoteToken,
     EnumCardFlipState? enumCardFlipState,
@@ -86,7 +84,6 @@ abstract class Coordinator {
     _navigationKey.currentState?.pushNamed(
       Routes.coinTradeScreen,
       arguments: {
-        'orderbookCubit': orderbookCubit,
         'balanceCubit': balanceCubit,
         'enumCardFlipState': enumCardFlipState ?? EnumCardFlipState.showFirst,
         'baseToken': baseToken,
@@ -119,14 +116,12 @@ abstract class Coordinator {
   static void goToBalanceCoinPreviewScreen({
     required AssetEntity asset,
     required BalanceCubit balanceCubit,
-    required OrderbookCubit orderbookCubit,
   }) {
     _navigationKey.currentState?.pushNamed(
       Routes.balanceCoinPreviewScreen,
       arguments: {
         'asset': asset,
         'balanceCubit': balanceCubit,
-        'orderbookCubit': orderbookCubit,
       },
     );
   }

--- a/lib/common/navigation/coordinator.dart
+++ b/lib/common/navigation/coordinator.dart
@@ -113,12 +113,12 @@ abstract class Coordinator {
     _navigationKey.currentState?.pushNamed(Routes.notifDetailsScreen);
   }
 
-  static void goToBalanceCoinPreviewScreen({
+  static void goToMarketDetailsScreen({
     required AssetEntity asset,
     required BalanceCubit balanceCubit,
   }) {
     _navigationKey.currentState?.pushNamed(
-      Routes.balanceCoinPreviewScreen,
+      Routes.marketDetailsScreen,
       arguments: {
         'asset': asset,
         'balanceCubit': balanceCubit,

--- a/lib/common/navigation/coordinator.dart
+++ b/lib/common/navigation/coordinator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/navigation/routes.dart';
+import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/utils/enums.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/screens/market_token_selection_screen.dart';
@@ -126,10 +127,15 @@ abstract class Coordinator {
     );
   }
 
-  static Future<MarketSelectionResultModel?>
-      goToMarketTokenSelectionScreen() async {
-    return await _navigationKey.currentState
-        ?.pushNamed(Routes.marketTokenSelectionScreen);
+  static Future<MarketSelectionResultModel?> goToMarketTokenSelectionScreen({
+    required OrderbookCubit orderbookCubit,
+  }) async {
+    return await _navigationKey.currentState?.pushNamed(
+      Routes.marketTokenSelectionScreen,
+      arguments: {
+        'orderbookCubit': orderbookCubit,
+      },
+    );
   }
 
   static void goToAppSettingsHelpScreen() {

--- a/lib/common/navigation/routes.dart
+++ b/lib/common/navigation/routes.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
-import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/utils/enums.dart';
 import 'package:polkadex/common/widgets/qr_code_screen.dart';
 import 'package:polkadex/features/app_settings_info/screens/app_settings_appearance.dart';
@@ -177,8 +176,6 @@ abstract class Routes {
             providers: [
               BlocProvider.value(
                   value: coinTradeArguments['balanceCubit'] as BalanceCubit),
-              BlocProvider.value(
-                  value: coinTradeArguments['orderbookCubit'] as OrderbookCubit)
             ],
             child: CoinTradeScreen(
               enumInitalCardFlipState:
@@ -220,9 +217,6 @@ abstract class Routes {
             providers: [
               BlocProvider.value(
                   value: balanceCoinArguments['balanceCubit'] as BalanceCubit),
-              BlocProvider.value(
-                  value:
-                      balanceCoinArguments['orderbookCubit'] as OrderbookCubit)
             ],
             child: BalanceCoinScreen(
               asset: balanceCoinArguments['asset'] as AssetEntity,

--- a/lib/common/navigation/routes.dart
+++ b/lib/common/navigation/routes.dart
@@ -51,7 +51,7 @@ abstract class Routes {
   static const balanceDepositScreenOne = '/balanceDepositOne';
   static const notifDepositScreen = '/notifDeposit';
   static const notifDetailsScreen = '/notifDetails';
-  static const marketDetailsScreen = '/marketDetailsScreen';
+  static const balanceCoinPreviewScreen = '/balanceCoinPreview';
   static const marketTokenSelectionScreen = '/marketTokenSelection';
   static const appSettingsHelpScreen = '/appSettingsHelp';
   static const balanceSummaryScreen = '/balanceSummary';
@@ -210,18 +210,17 @@ abstract class Routes {
           return NotifDetailsScreen();
         };
         break;
-      case marketDetailsScreen:
+      case balanceCoinPreviewScreen:
         builder = (_) {
-          final marketDetailsArguments = settings.arguments as Map;
+          final balanceCoinArguments = settings.arguments as Map;
 
           return MultiBlocProvider(
             providers: [
               BlocProvider.value(
-                  value:
-                      marketDetailsArguments['balanceCubit'] as BalanceCubit),
+                  value: balanceCoinArguments['balanceCubit'] as BalanceCubit),
             ],
-            child: MarketDetailsScreen(
-              asset: marketDetailsArguments['asset'] as AssetEntity,
+            child: BalanceCoinScreen(
+              asset: balanceCoinArguments['asset'] as AssetEntity,
             ),
           );
         };

--- a/lib/common/navigation/routes.dart
+++ b/lib/common/navigation/routes.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
+import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/utils/enums.dart';
 import 'package:polkadex/common/widgets/qr_code_screen.dart';
 import 'package:polkadex/features/app_settings_info/screens/app_settings_appearance.dart';
@@ -228,7 +229,13 @@ abstract class Routes {
       case marketTokenSelectionScreen:
         return MaterialPageRoute<MarketSelectionResultModel>(
           builder: (_) {
-            return MarketTokenSelectionScreen();
+            final marketTokenSelectionArguments = settings.arguments as Map;
+
+            return BlocProvider.value(
+              value: marketTokenSelectionArguments['orderbookCubit']
+                  as OrderbookCubit,
+              child: MarketTokenSelectionScreen(),
+            );
           },
           settings: settings,
         );

--- a/lib/common/navigation/routes.dart
+++ b/lib/common/navigation/routes.dart
@@ -50,7 +50,7 @@ abstract class Routes {
   static const balanceDepositScreenOne = '/balanceDepositOne';
   static const notifDepositScreen = '/notifDeposit';
   static const notifDetailsScreen = '/notifDetails';
-  static const balanceCoinPreviewScreen = '/balanceCoinPreview';
+  static const marketDetailsScreen = '/marketDetailsScreen';
   static const marketTokenSelectionScreen = '/marketTokenSelection';
   static const appSettingsHelpScreen = '/appSettingsHelp';
   static const balanceSummaryScreen = '/balanceSummary';
@@ -209,17 +209,18 @@ abstract class Routes {
           return NotifDetailsScreen();
         };
         break;
-      case balanceCoinPreviewScreen:
+      case marketDetailsScreen:
         builder = (_) {
-          final balanceCoinArguments = settings.arguments as Map;
+          final marketDetailsArguments = settings.arguments as Map;
 
           return MultiBlocProvider(
             providers: [
               BlocProvider.value(
-                  value: balanceCoinArguments['balanceCubit'] as BalanceCubit),
+                  value:
+                      marketDetailsArguments['balanceCubit'] as BalanceCubit),
             ],
-            child: BalanceCoinScreen(
-              asset: balanceCoinArguments['asset'] as AssetEntity,
+            child: MarketDetailsScreen(
+              asset: marketDetailsArguments['asset'] as AssetEntity,
             ),
           );
         };

--- a/lib/common/utils/time_utils.dart
+++ b/lib/common/utils/time_utils.dart
@@ -11,15 +11,15 @@ abstract class TimeUtils {
       case EnumAppChartTimestampTypes.thirtyMinutes:
         return "30m";
       case EnumAppChartTimestampTypes.oneHour:
-        return "1h";
+        return "1H";
       case EnumAppChartTimestampTypes.fourHours:
-        return "4h";
+        return "4H";
       case EnumAppChartTimestampTypes.twelveHours:
-        return "12h";
+        return "12H";
       case EnumAppChartTimestampTypes.oneDay:
         return "1D";
       case EnumAppChartTimestampTypes.oneWeek:
-        return "1w";
+        return "1W";
       case EnumAppChartTimestampTypes.oneMonth:
         return "1M";
     }

--- a/lib/features/coin/presentation/screens/balance_coin_screen.dart
+++ b/lib/features/coin/presentation/screens/balance_coin_screen.dart
@@ -40,16 +40,17 @@ enum _EnumMenus {
 
 /// XD_PAGE: 20
 /// XD_PAGE: 31
-class MarketDetailsScreen extends StatefulWidget {
-  MarketDetailsScreen({required this.asset});
+class BalanceCoinScreen extends StatefulWidget {
+  BalanceCoinScreen({required this.asset});
 
   final AssetEntity asset;
 
   @override
-  _MarketDetailsScreenState createState() => _MarketDetailsScreenState();
+  _BalanceCoinPreviewScreenState createState() =>
+      _BalanceCoinPreviewScreenState();
 }
 
-class _MarketDetailsScreenState extends State<MarketDetailsScreen>
+class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
     with TickerProviderStateMixin {
   final _isShowGraphNotifier = ValueNotifier<bool>(false);
   final List<Enum> _typeFilters = [];

--- a/lib/features/coin/presentation/screens/balance_coin_screen.dart
+++ b/lib/features/coin/presentation/screens/balance_coin_screen.dart
@@ -7,7 +7,6 @@ import 'package:polkadex/common/dummy_providers/balance_chart_dummy_provider.dar
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
-import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/cubits/account_cubit/account_cubit.dart';
 import 'package:polkadex/common/trades/domain/entities/account_trade_entity.dart';
 import 'package:polkadex/common/utils/colors.dart';
@@ -192,8 +191,6 @@ class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
                               child: buildInkWell(
                                 borderRadius: BorderRadius.circular(20),
                                 onTap: () => Coordinator.goToCoinTradeScreen(
-                                    orderbookCubit:
-                                        context.read<OrderbookCubit>(),
                                     balanceCubit: context.read<BalanceCubit>(),
                                     baseToken: widget.asset,
                                     quoteToken: context
@@ -229,7 +226,6 @@ class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
                                 .read<MarketAssetCubit>()
                                 .listAvailableMarkets[index][1],
                             onTap: () => Coordinator.goToCoinTradeScreen(
-                                orderbookCubit: context.read<OrderbookCubit>(),
                                 baseToken: context
                                     .read<MarketAssetCubit>()
                                     .listAvailableMarkets[index][0],

--- a/lib/features/coin/presentation/screens/balance_coin_screen.dart
+++ b/lib/features/coin/presentation/screens/balance_coin_screen.dart
@@ -40,17 +40,16 @@ enum _EnumMenus {
 
 /// XD_PAGE: 20
 /// XD_PAGE: 31
-class BalanceCoinScreen extends StatefulWidget {
-  BalanceCoinScreen({required this.asset});
+class MarketDetailsScreen extends StatefulWidget {
+  MarketDetailsScreen({required this.asset});
 
   final AssetEntity asset;
 
   @override
-  _BalanceCoinPreviewScreenState createState() =>
-      _BalanceCoinPreviewScreenState();
+  _MarketDetailsScreenState createState() => _MarketDetailsScreenState();
 }
 
-class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
+class _MarketDetailsScreenState extends State<MarketDetailsScreen>
     with TickerProviderStateMixin {
   final _isShowGraphNotifier = ValueNotifier<bool>(false);
   final List<Enum> _typeFilters = [];

--- a/lib/features/landing/presentation/screens/market_token_selection_screen.dart
+++ b/lib/features/landing/presentation/screens/market_token_selection_screen.dart
@@ -627,9 +627,9 @@ class _ThisProvider extends ChangeNotifier {
                     ),
           )
           .toList();
-      return filteredMarkets.map((market) => market[0]).toList();
+      return filteredMarkets.map((market) => market[0]).toSet().toList();
     } else {
-      return _marketList.map((market) => market[0]).toList();
+      return _marketList.map((market) => market[0]).toSet().toList();
     }
   }
 

--- a/lib/features/landing/presentation/screens/market_token_selection_screen.dart
+++ b/lib/features/landing/presentation/screens/market_token_selection_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:polkadex/common/configs/app_config.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
+import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/features/landing/presentation/providers/token_pair_expanded_provider.dart';
 import 'package:polkadex/common/utils/colors.dart';
 import 'package:polkadex/common/utils/extensions.dart';
@@ -234,13 +235,11 @@ class _ThisQuoteLayoutWidget extends AnimatedWidget {
               builder: (context, thisProvider, child) => ListView.builder(
                 physics: BouncingScrollPhysics(),
                 itemBuilder: (context, index) => InkWell(
-                  onTap: () {
-                    thisProvider.selectedQuoteToken =
-                        thisProvider.quoteList[index];
-                    Navigator.of(context).pop(MarketSelectionResultModel(
-                        selectedBaseAsset: thisProvider.selectedBaseToken!,
-                        selectedQuoteAsset: thisProvider.selectedQuoteToken!));
-                  },
+                  onTap: () => _onMarketSelected(
+                    context,
+                    thisProvider,
+                    index,
+                  ),
                   child: _ThisQuoteItemWidget(
                     asset: thisProvider.quoteList[index],
                     isSelected: thisProvider.quoteList[index].assetId ==
@@ -254,6 +253,25 @@ class _ThisQuoteLayoutWidget extends AnimatedWidget {
           )
         ],
       ),
+    );
+  }
+
+  void _onMarketSelected(
+    BuildContext context,
+    _ThisProvider provider,
+    int index,
+  ) {
+    provider.selectedQuoteToken = provider.quoteList[index];
+
+    context.read<OrderbookCubit>().fetchOrderbookData(
+          leftTokenId: provider.selectedBaseToken!.assetId,
+          rightTokenId: provider.selectedQuoteToken!.assetId,
+        );
+
+    Navigator.of(context).pop(
+      MarketSelectionResultModel(
+          selectedBaseAsset: provider.selectedBaseToken!,
+          selectedQuoteAsset: provider.selectedQuoteToken!),
     );
   }
 }

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -5,7 +5,6 @@ import 'package:polkadex/common/configs/app_config.dart';
 import 'package:polkadex/common/dummy_providers/balance_chart_dummy_provider.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
-import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/widgets/check_box_widget.dart';
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
 import 'package:polkadex/common/utils/colors.dart';
@@ -324,8 +323,6 @@ class _BalanceTabViewState extends State<BalanceTabView>
                                     Coordinator.goToBalanceCoinPreviewScreen(
                                   asset: asset,
                                   balanceCubit: context.read<BalanceCubit>(),
-                                  orderbookCubit:
-                                      context.read<OrderbookCubit>(),
                                 ),
                                 child: BalanceItemWidget(
                                   tokenAcronym: asset.symbol,

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -320,7 +320,7 @@ class _BalanceTabViewState extends State<BalanceTabView>
 
                               return InkWell(
                                 onTap: () =>
-                                    Coordinator.goToMarketDetailsScreen(
+                                    Coordinator.goToBalanceCoinPreviewScreen(
                                   asset: asset,
                                   balanceCubit: context.read<BalanceCubit>(),
                                 ),

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -320,7 +320,7 @@ class _BalanceTabViewState extends State<BalanceTabView>
 
                               return InkWell(
                                 onTap: () =>
-                                    Coordinator.goToBalanceCoinPreviewScreen(
+                                    Coordinator.goToMarketDetailsScreen(
                                   asset: asset,
                                   balanceCubit: context.read<BalanceCubit>(),
                                 ),

--- a/lib/features/landing/presentation/sub_views/exchange_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/exchange_tab_view.dart
@@ -6,7 +6,6 @@ import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/features/landing/domain/entities/ticker_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
-import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/cubits/ticker_cubit/ticker_cubit.dart';
 import 'package:polkadex/features/landing/presentation/providers/exchange_loading_provider.dart';
@@ -513,7 +512,6 @@ class _ThisListItemWidget extends StatelessWidget {
           baseToken: baseAsset,
           quoteToken: quoteAsset,
           balanceCubit: context.read<BalanceCubit>(),
-          orderbookCubit: context.read<OrderbookCubit>(),
         ),
         borderRadius: BorderRadius.circular(20),
         child: Container(

--- a/lib/features/landing/presentation/sub_views/home_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/home_tab_view.dart
@@ -125,7 +125,7 @@ class _HomeTabViewState extends State<HomeTabView>
                     return TopPairWidget(
                       leftAsset: baseAsset,
                       rightAsset: quoteAsset,
-                      onTap: () => Coordinator.goToMarketDetailsScreen(
+                      onTap: () => Coordinator.goToBalanceCoinPreviewScreen(
                         asset: context
                             .read<MarketAssetCubit>()
                             .listAvailableMarkets[index][0],

--- a/lib/features/landing/presentation/sub_views/home_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/home_tab_view.dart
@@ -4,7 +4,6 @@ import 'package:polkadex/common/configs/app_config.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
-import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/features/landing/domain/entities/ticker_entity.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/cubits/ticker_cubit/ticker_cubit.dart';
@@ -131,7 +130,6 @@ class _HomeTabViewState extends State<HomeTabView>
                             .read<MarketAssetCubit>()
                             .listAvailableMarkets[index][0],
                         balanceCubit: context.read<BalanceCubit>(),
-                        orderbookCubit: context.read<OrderbookCubit>(),
                       ),
                       ticker: state is TickerLoaded
                           ? state.ticker[
@@ -403,7 +401,6 @@ class _ThisRankingListItemWidget extends StatelessWidget {
           baseToken: baseAsset,
           quoteToken: quoteAsset,
           balanceCubit: context.read<BalanceCubit>(),
-          orderbookCubit: context.read<OrderbookCubit>(),
         ),
         child: Container(
           decoration: BoxDecoration(

--- a/lib/features/landing/presentation/sub_views/home_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/home_tab_view.dart
@@ -125,7 +125,7 @@ class _HomeTabViewState extends State<HomeTabView>
                     return TopPairWidget(
                       leftAsset: baseAsset,
                       rightAsset: quoteAsset,
-                      onTap: () => Coordinator.goToBalanceCoinPreviewScreen(
+                      onTap: () => Coordinator.goToMarketDetailsScreen(
                         asset: context
                             .read<MarketAssetCubit>()
                             .listAvailableMarkets[index][0],

--- a/lib/features/landing/presentation/sub_views/trade_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/trade_tab_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
 import 'package:polkadex/common/cubits/account_cubit/account_cubit.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
+import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/trades/presentation/cubits/order_history_cubit/order_history_cubit.dart';
 import 'package:polkadex/common/utils/extensions.dart';
 import 'package:polkadex/features/landing/domain/entities/ticker_entity.dart';
@@ -199,7 +200,9 @@ class _ThisTopRowSelectWidget extends StatelessWidget {
       isPriceTrendDown() ? AppColors.colorE6007A : AppColors.color0CA564;
 
   void _onMarketSelection(BuildContext context) {
-    Coordinator.goToMarketTokenSelectionScreen().then(
+    Coordinator.goToMarketTokenSelectionScreen(
+            orderbookCubit: context.read<OrderbookCubit>())
+        .then(
       (model) {
         if (model != null) {
           context.read<MarketAssetCubit>().changeSelectedMarket(

--- a/lib/features/landing/presentation/widgets/place_order_widget.dart
+++ b/lib/features/landing/presentation/widgets/place_order_widget.dart
@@ -490,7 +490,7 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
                 controller: _priceController,
                 onChanged: (price) => _onPriceAmountChanged(
                   context.read<PlaceOrderCubit>(),
-                  double.parse(price),
+                  double.tryParse(price) ?? 0.0,
                   false,
                 ),
                 isLoading: _orderTypeNotifier.value == EnumOrderTypes.market &&
@@ -528,7 +528,7 @@ class _PlaceOrderWidgetState extends State<PlaceOrderWidget> {
             controller: _amountController,
             onChanged: (amount) => _onPriceAmountChanged(
               context.read<PlaceOrderCubit>(),
-              double.parse(amount),
+              double.tryParse(amount) ?? 0.0,
               true,
             ),
           ),

--- a/lib/features/landing/presentation/widgets/quantity_input_widget.dart
+++ b/lib/features/landing/presentation/widgets/quantity_input_widget.dart
@@ -74,7 +74,7 @@ class QuantityInputWidget extends StatelessWidget {
                       ),
                       keyboardType: TextInputType.numberWithOptions(
                         decimal: true,
-                        signed: false,
+                        signed: true,
                       ),
                       onChanged: onChanged,
                       inputFormatters: [

--- a/lib/features/trade/presentation/screens/coin_trade_screen.dart
+++ b/lib/features/trade/presentation/screens/coin_trade_screen.dart
@@ -18,6 +18,7 @@ import 'package:polkadex/features/trade/presentation/cubits/coin_graph_state.dar
 import 'package:polkadex/features/trade/presentation/widgets/card_flip_widgett.dart';
 import 'package:polkadex/features/trade/presentation/widgets/coin_graph_shimmer_widget.dart';
 import 'package:polkadex/common/orderbook/presentation/widgets/order_book_widget.dart';
+import 'package:polkadex/common/orderbook/presentation/cubit/orderbook_cubit.dart';
 import 'package:polkadex/common/providers/bottom_navigation_provider.dart';
 import 'package:polkadex/common/utils/colors.dart';
 import 'package:polkadex/common/utils/enums.dart';
@@ -31,11 +32,6 @@ import 'dart:math' as math;
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:polkadex/injection_container.dart';
 
-/// XD_PAGE: 24
-/// XD_PAGE: 25
-/// XD_PAGE: 26
-/// XD_PAGE: 27
-/// XD_PAGE: 33
 class CoinTradeScreen extends StatefulWidget {
   const CoinTradeScreen({
     required this.leftToken,
@@ -84,12 +80,23 @@ class _CoinTradeScreenState extends State<CoinTradeScreen> {
           create: (context) => AppChartDummyProvider(),
         ),
       ],
-      builder: (context, _) => BlocProvider<CoinGraphCubit>(
-        create: (_) => dependency<CoinGraphCubit>()
-          ..loadGraph(
-            widget.leftToken.assetId,
-            widget.rightToken.assetId,
+      builder: (context, _) => MultiBlocProvider(
+        providers: [
+          BlocProvider<CoinGraphCubit>(
+            create: (_) => dependency<CoinGraphCubit>()
+              ..loadGraph(
+                widget.leftToken.assetId,
+                widget.rightToken.assetId,
+              ),
           ),
+          BlocProvider<OrderbookCubit>(
+            create: (_) => dependency<OrderbookCubit>()
+              ..fetchOrderbookData(
+                leftTokenId: widget.leftToken.assetId,
+                rightTokenId: widget.rightToken.assetId,
+              ),
+          ),
+        ],
         child: Scaffold(
           backgroundColor: AppColors.color1C2023,
           body: SafeArea(

--- a/lib/features/trade/presentation/screens/coin_trade_screen.dart
+++ b/lib/features/trade/presentation/screens/coin_trade_screen.dart
@@ -565,34 +565,34 @@ class _ThisGraphOptionWidget extends StatelessWidget {
                       builder: (context, state) {
                         return Row(
                           children: [
-                            ...EnumAppChartTimestampTypes.values
-                                .map<Widget>((item) => InkWell(
-                                      onTap: () => context
-                                          .read<CoinGraphCubit>()
-                                          .loadGraph(
+                            ...EnumAppChartTimestampTypes.values.map<Widget>(
+                              (item) {
+                                return InkWell(
+                                  onTap: () =>
+                                      context.read<CoinGraphCubit>().loadGraph(
                                             leftToken.assetId,
                                             rightToken.assetId,
                                             timestampSelected: item,
                                           ),
-                                      child: AnimatedContainer(
-                                        duration: AppConfigs.animDurationSmall,
-                                        width: containerWidth,
-                                        height: containerWidth,
-                                        alignment: Alignment.center,
-                                        decoration: BoxDecoration(
-                                          borderRadius:
-                                              BorderRadius.circular(10),
-                                          color: state.timestampSelected == item
-                                              ? AppColors.colorE6007A
-                                              : null,
-                                        ),
-                                        child: Text(
-                                          TimeUtils.timestampTypeToString(item),
-                                          style: tsS13W600CFF,
-                                        ),
-                                      ),
-                                    ))
-                                .toList(),
+                                  child: AnimatedContainer(
+                                    duration: AppConfigs.animDurationSmall,
+                                    width: containerWidth,
+                                    height: containerWidth,
+                                    alignment: Alignment.center,
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(10),
+                                      color: state.timestampSelected == item
+                                          ? AppColors.colorE6007A
+                                          : null,
+                                    ),
+                                    child: Text(
+                                      _timestampToUiString(item),
+                                      style: tsS13W600CFF,
+                                    ),
+                                  ),
+                                );
+                              },
+                            ).toList(),
                           ],
                         );
                       },
@@ -605,6 +605,16 @@ class _ThisGraphOptionWidget extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _timestampToUiString(EnumAppChartTimestampTypes timestamp) {
+    String timestampString = TimeUtils.timestampTypeToString(timestamp);
+
+    if (timestamp != EnumAppChartTimestampTypes.oneMonth) {
+      timestampString = timestampString.toLowerCase();
+    }
+
+    return timestampString;
   }
 }
 

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -331,8 +331,8 @@ Future<void> init() async {
     () => OrderbookRemoteDatasource(),
   );
 
-  dependency.registerSingleton<IOrderbookRepository>(
-    OrderbookRepository(
+  dependency.registerFactory<IOrderbookRepository>(
+    () => OrderbookRepository(
       orderbookRemoteDatasource: dependency(),
     ),
   );


### PR DESCRIPTION
This PR contains the following fixes:

- Makes the graph work for some timestamps that weren't working before (1h, 4h, 12h, 1w);
- Fixes double parsing when there was no value in the quantity widget;
- Shows done button on ios virtual keyboard;
- Make the market list show only unique base options in the market switch screen (removes duplicate options);
- Shows the correct orderbook data in the coin market screen;
- Shows the correct orderbook data in the exchange screen depending on which market is selected currently.