### PR TITLE
Feature/wallet screen revamp

### DIFF
--- a/lib/common/market_asset/presentation/cubit/market_asset_cubit.dart
+++ b/lib/common/market_asset/presentation/cubit/market_asset_cubit.dart
@@ -22,7 +22,7 @@ class MarketAssetCubit extends Cubit<MarketAssetState> {
   final Map<String, AssetEntity> _assets = {};
 
   List<List<AssetEntity>> get listAvailableMarkets => _marketsList;
-  Map<String, List<String>> get mapAvailableMarkets => _marketsMap;
+  Map<String, AssetEntity> get mapAvailableAssets => _assets;
 
   AssetEntity get currentBaseAssetDetails {
     final currentState = state;

--- a/lib/common/utils/styles.dart
+++ b/lib/common/utils/styles.dart
@@ -163,6 +163,12 @@ TextStyle get tsS20W500CFF => TextStyle(
       color: AppColors.colorFFFFFF,
     );
 
+TextStyle get tsS20W400CFF => TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.w400,
+      color: AppColors.colorFFFFFF,
+    );
+
 TextStyle get tsS14W400CFF => TextStyle(
       fontSize: 14,
       fontWeight: FontWeight.w400,

--- a/lib/common/widgets/app_buttons.dart
+++ b/lib/common/widgets/app_buttons.dart
@@ -108,6 +108,7 @@ class AppButton extends StatelessWidget {
               child: Padding(
                 padding: innerPadding,
                 child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     leadingWidget ?? Container(),

--- a/lib/common/widgets/app_buttons.dart
+++ b/lib/common/widgets/app_buttons.dart
@@ -48,6 +48,7 @@ class AppBackButton extends StatelessWidget {
 class AppButton extends StatelessWidget {
   AppButton({
     required this.label,
+    this.leadingWidget,
     this.enabled = true,
     this.onTap,
     this.innerPadding =
@@ -60,6 +61,7 @@ class AppButton extends StatelessWidget {
   final _notifier = ValueNotifier<bool>(false);
 
   final String label;
+  final Widget? leadingWidget;
   final bool enabled;
   final VoidCallback? onTap;
   final EdgeInsets innerPadding;
@@ -105,11 +107,18 @@ class AppButton extends StatelessWidget {
               ),
               child: Padding(
                 padding: innerPadding,
-                child: Text(
-                  label,
-                  textAlign: TextAlign.center,
-                  style: tsS18W600CFF.copyWith(
-                      color: enabled ? textColor : AppColors.colorFFFFFF),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    leadingWidget ?? Container(),
+                    if (leadingWidget != null) SizedBox(width: 8),
+                    Text(
+                      label,
+                      textAlign: TextAlign.center,
+                      style: tsS18W600CFF.copyWith(
+                          color: enabled ? textColor : AppColors.colorFFFFFF),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/lib/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart
+++ b/lib/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart
@@ -86,19 +86,26 @@ class TradeHistoryCubit extends Cubit<TradeHistoryState> {
     DateTimeRange? dateFilter,
   }) async {
     List<AccountTradeEntity> _tradesFiltered = [..._allTrades];
+    final currentState = state;
 
-    if (dateFilter != null) {
-      _tradesFiltered.removeWhere((trade) =>
-          trade.time.isBefore(dateFilter.start) ||
-          trade.time.isAfter(dateFilter.end));
+    if (state is TradeHistoryLoaded) {
+      if (dateFilter != null) {
+        _tradesFiltered.removeWhere((trade) =>
+            trade.time.isBefore(dateFilter.start) ||
+            trade.time.isAfter(dateFilter.end));
+      }
+
+      if (filters.isNotEmpty) {
+        _tradesFiltered
+            .removeWhere((trade) => !filters.contains(trade.txnType));
+      }
+
+      emit(
+        TradeHistoryLoaded(
+          trades: _tradesFiltered,
+          assetSelected: currentState.assetSelected,
+        ),
+      );
     }
-
-    if (filters.isNotEmpty) {
-      _tradesFiltered.removeWhere((trade) => !filters.contains(trade.txnType));
-    }
-
-    emit(
-      TradeHistoryLoaded(trades: _tradesFiltered),
-    );
   }
 }

--- a/lib/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart
+++ b/lib/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart
@@ -22,10 +22,12 @@ class TradeHistoryCubit extends Cubit<TradeHistoryState> {
 
   List<AccountTradeEntity> _allTrades = [];
 
-  Future<void> getAccountTrades(
-    AssetEntity asset,
-    String address,
-  ) async {
+  Future<void> getAccountTrades({
+    required AssetEntity asset,
+    required String address,
+    List<Enum> filters = const [],
+    DateTimeRange? dateFilter,
+  }) async {
     emit(TradeHistoryLoading(assetSelected: asset));
 
     final result = await _getTradesUseCase(
@@ -42,10 +44,17 @@ class TradeHistoryCubit extends Cubit<TradeHistoryState> {
         if (currentState is TradeHistoryLoaded) {
           final newList = [newTrade, ...currentState.trades];
 
-          emit(TradeHistoryLoaded(
-            assetSelected: asset,
-            trades: newList,
-          ));
+          filters.isNotEmpty || dateFilter != null
+              ? updateTradeHistoryFilter(
+                  filters: filters,
+                  dateFilter: dateFilter,
+                )
+              : emit(
+                  TradeHistoryLoaded(
+                    assetSelected: asset,
+                    trades: newList,
+                  ),
+                );
         }
       },
       onMsgError: (error) => emit(
@@ -73,16 +82,23 @@ class TradeHistoryCubit extends Cubit<TradeHistoryState> {
         }).toList();
         _allTrades.sort((a, b) => b.time.compareTo(a.time));
 
-        emit(TradeHistoryLoaded(
-          assetSelected: asset,
-          trades: _allTrades,
-        ));
+        filters.isNotEmpty || dateFilter != null
+            ? updateTradeHistoryFilter(
+                filters: filters,
+                dateFilter: dateFilter,
+              )
+            : emit(
+                TradeHistoryLoaded(
+                  assetSelected: asset,
+                  trades: _allTrades,
+                ),
+              );
       },
     );
   }
 
   Future<void> updateTradeHistoryFilter({
-    required List<Enum> filters,
+    List<Enum> filters = const [],
     DateTimeRange? dateFilter,
   }) async {
     List<AccountTradeEntity> _tradesFiltered = [..._allTrades];

--- a/lib/features/coin/presentation/cubits/trade_history_cubit/trade_history_state.dart
+++ b/lib/features/coin/presentation/cubits/trade_history_cubit/trade_history_state.dart
@@ -1,30 +1,50 @@
 part of 'trade_history_cubit.dart';
 
 abstract class TradeHistoryState extends Equatable {
-  const TradeHistoryState();
+  const TradeHistoryState({this.assetSelected});
+
+  final AssetEntity? assetSelected;
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [assetSelected];
 }
 
-class TradeHistoryInitial extends TradeHistoryState {}
+class TradeHistoryInitial extends TradeHistoryState {
+  TradeHistoryInitial({AssetEntity? assetSelected})
+      : super(assetSelected: assetSelected);
+}
 
-class TradeHistoryLoading extends TradeHistoryState {}
+class TradeHistoryLoading extends TradeHistoryState {
+  TradeHistoryLoading({AssetEntity? assetSelected})
+      : super(assetSelected: assetSelected);
+}
 
 class TradeHistoryError extends TradeHistoryState {
-  TradeHistoryError({required this.message});
+  TradeHistoryError({
+    required this.message,
+    AssetEntity? assetSelected,
+  }) : super(assetSelected: assetSelected);
 
   final String message;
 
   @override
-  List<Object> get props => [message];
+  List<Object?> get props => [
+        message,
+        assetSelected,
+      ];
 }
 
 class TradeHistoryLoaded extends TradeHistoryState {
-  const TradeHistoryLoaded({required this.trades});
+  const TradeHistoryLoaded({
+    required this.trades,
+    AssetEntity? assetSelected,
+  }) : super(assetSelected: assetSelected);
 
   final List<AccountTradeEntity> trades;
 
   @override
-  List<Object> get props => [trades];
+  List<Object?> get props => [
+        trades,
+        assetSelected,
+      ];
 }

--- a/lib/features/coin/presentation/screens/balance_coin_screen.dart
+++ b/lib/features/coin/presentation/screens/balance_coin_screen.dart
@@ -48,7 +48,7 @@ class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
     return BlocProvider(
       create: (_) => dependency<TradeHistoryCubit>()
         ..getAccountTrades(
-          widget.asset.assetId,
+          widget.asset,
           context.read<AccountCubit>().mainAccountAddress,
         ),
       child: MultiProvider(
@@ -356,7 +356,7 @@ class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
                                   onRefresh: () => context
                                       .read<TradeHistoryCubit>()
                                       .getAccountTrades(
-                                        widget.asset.assetId,
+                                        widget.asset,
                                         context
                                             .read<AccountCubit>()
                                             .mainAccountAddress,

--- a/lib/features/coin/presentation/screens/balance_coin_screen.dart
+++ b/lib/features/coin/presentation/screens/balance_coin_screen.dart
@@ -48,8 +48,8 @@ class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
     return BlocProvider(
       create: (_) => dependency<TradeHistoryCubit>()
         ..getAccountTrades(
-          widget.asset,
-          context.read<AccountCubit>().mainAccountAddress,
+          asset: widget.asset,
+          address: context.read<AccountCubit>().mainAccountAddress,
         ),
       child: MultiProvider(
         providers: [
@@ -356,8 +356,8 @@ class _BalanceCoinPreviewScreenState extends State<BalanceCoinScreen>
                                   onRefresh: () => context
                                       .read<TradeHistoryCubit>()
                                       .getAccountTrades(
-                                        widget.asset,
-                                        context
+                                        asset: widget.asset,
+                                        address: context
                                             .read<AccountCubit>()
                                             .mainAccountAddress,
                                       ),

--- a/lib/features/landing/presentation/screens/landing_screen.dart
+++ b/lib/features/landing/presentation/screens/landing_screen.dart
@@ -9,6 +9,7 @@ import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/bala
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
 import 'package:polkadex/features/landing/presentation/providers/notification_drawer_provider.dart';
 import 'package:polkadex/features/landing/presentation/cubits/recent_trades_cubit/recent_trades_cubit.dart';
+import 'package:polkadex/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart';
 import 'package:polkadex/features/landing/presentation/sub_views/balance_tab_view.dart';
 import 'package:polkadex/features/landing/presentation/sub_views/exchange_tab_view.dart';
 import 'package:polkadex/features/landing/presentation/sub_views/home_tab_view.dart';
@@ -122,6 +123,9 @@ class _LandingScreenState extends State<LandingScreen>
                     .currentQuoteAssetDetails
                     .assetId,
               ),
+          ),
+          BlocProvider<TradeHistoryCubit>(
+            create: (_) => dependency<TradeHistoryCubit>(),
           ),
         ],
         child: MultiProvider(

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -12,11 +12,14 @@ import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/bala
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
 import 'package:polkadex/features/coin/presentation/widgets/order_history_shimmer_widget.dart';
 import 'package:polkadex/features/landing/presentation/widgets/trade_item_widget.dart';
+import 'package:polkadex/common/widgets/custom_date_range_picker.dart';
 import 'package:polkadex/common/utils/colors.dart';
 import 'package:polkadex/common/utils/styles.dart';
+import 'package:polkadex/common/utils/enums.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
 import 'package:polkadex/features/landing/utils/token_utils.dart';
 import 'package:polkadex/common/widgets/polkadex_progress_error_widget.dart';
+
 import 'package:polkadex/common/cubits/account_cubit/account_cubit.dart';
 import 'package:provider/provider.dart';
 
@@ -31,6 +34,8 @@ class _BalanceTabViewState extends State<BalanceTabView>
     with TickerProviderStateMixin {
   late ScrollController _scrollController;
   late AnimationController _controller;
+  final List<Enum> _typeFilters = [];
+  DateTimeRange? _dateRange;
 
   @override
   void initState() {
@@ -87,14 +92,128 @@ class _BalanceTabViewState extends State<BalanceTabView>
                         },
                         child: state.assetSelected != null
                             ? Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 8),
-                                child: Column(
+                                padding: const EdgeInsets.all(16),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
                                   children: [
                                     Text(
-                                      'Summary of Trades',
+                                      'Trades',
                                       style: tsS18W600CFF,
                                       textAlign: TextAlign.center,
+                                    ),
+                                    Row(
+                                      children: [
+                                        Padding(
+                                          padding:
+                                              const EdgeInsets.only(right: 6),
+                                          child: InkWell(
+                                            onTap: () =>
+                                                _onBuyFilterButtonPress(
+                                                    context),
+                                            child: Container(
+                                              width: 36,
+                                              height: 36,
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                      vertical: 7.0,
+                                                      horizontal: 9),
+                                              decoration: BoxDecoration(
+                                                  color: _typeFilters.contains(
+                                                          EnumBuySell.buy)
+                                                      ? Colors.white
+                                                      : AppColors.color8BA1BE
+                                                          .withOpacity(0.2),
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          12)),
+                                              child: SvgPicture.asset(
+                                                (_typeFilters.contains(
+                                                            EnumBuySell.buy)
+                                                        ? 'buysel'
+                                                        : 'buy')
+                                                    .asAssetSvg(),
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                        Padding(
+                                          padding:
+                                              const EdgeInsets.only(right: 6),
+                                          child: InkWell(
+                                            onTap: () =>
+                                                _onSellFilterButtonPress(
+                                                    context),
+                                            child: Container(
+                                              width: 36,
+                                              height: 36,
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                      vertical: 7.0,
+                                                      horizontal: 9),
+                                              decoration: BoxDecoration(
+                                                  color: _typeFilters.contains(
+                                                          EnumBuySell.sell)
+                                                      ? Colors.white
+                                                      : AppColors.color8BA1BE
+                                                          .withOpacity(0.2),
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          12)),
+                                              child: SvgPicture.asset(
+                                                (_typeFilters.contains(
+                                                            EnumBuySell.sell)
+                                                        ? 'sellsel'
+                                                        : 'sell')
+                                                    .asAssetSvg(),
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                        SizedBox(width: 14),
+                                        Theme(
+                                          data: Theme.of(context).copyWith(
+                                              primaryColor: AppColors
+                                                  .color1C2023,
+                                              cardColor: Colors.red,
+                                              colorScheme:
+                                                  ColorScheme.fromSwatch()
+                                                      .copyWith(
+                                                          secondary: AppColors
+                                                              .colorE6007A),
+                                              buttonTheme: ButtonThemeData(
+                                                  highlightColor: Colors.green,
+                                                  buttonColor: Colors.green,
+                                                  textTheme:
+                                                      ButtonTextTheme.accent)),
+                                          child: Builder(
+                                            builder: (context) => InkWell(
+                                              onTap: () async =>
+                                                  _onDateFilterButtonPress(
+                                                      context),
+                                              child: Container(
+                                                width: 36,
+                                                height: 36,
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                        vertical: 7.0,
+                                                        horizontal: 9),
+                                                decoration: BoxDecoration(
+                                                    color: _dateRange != null
+                                                        ? AppColors.colorE6007A
+                                                        : AppColors.color8BA1BE
+                                                            .withOpacity(0.2),
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            12)),
+                                                child: SvgPicture.asset(
+                                                  'calendar'.asAssetSvg(),
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      ],
                                     ),
                                   ],
                                 ),
@@ -213,6 +332,41 @@ class _BalanceTabViewState extends State<BalanceTabView>
     } else {
       return DateFormat("dd MMMM, yyyy").format(date);
     }
+  }
+
+  void _onBuyFilterButtonPress(BuildContext context) {
+    setState(() => _typeFilters.contains(EnumBuySell.buy)
+        ? _typeFilters.remove(EnumBuySell.buy)
+        : _typeFilters.add(EnumBuySell.buy));
+
+    context.read<TradeHistoryCubit>().updateTradeHistoryFilter(
+          filters: _typeFilters,
+          dateFilter: _dateRange,
+        );
+  }
+
+  void _onSellFilterButtonPress(BuildContext context) {
+    setState(() => _typeFilters.contains(EnumBuySell.sell)
+        ? _typeFilters.remove(EnumBuySell.sell)
+        : _typeFilters.add(EnumBuySell.sell));
+
+    context.read<TradeHistoryCubit>().updateTradeHistoryFilter(
+          filters: _typeFilters,
+          dateFilter: _dateRange,
+        );
+  }
+
+  Future<void> _onDateFilterButtonPress(BuildContext context) async {
+    final _tempDate = await CustomDateRangePicker.call(
+        filterStartDate: _dateRange?.start,
+        filterEndDate: _dateRange?.end,
+        context: context);
+    setState(() => _dateRange = _tempDate);
+
+    context.read<TradeHistoryCubit>().updateTradeHistoryFilter(
+          filters: _typeFilters,
+          dateFilter: _dateRange,
+        );
   }
 
   void _onScrollListener() {

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -5,7 +5,6 @@ import 'package:polkadex/common/configs/app_config.dart';
 import 'package:polkadex/common/dummy_providers/balance_chart_dummy_provider.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
-import 'package:polkadex/common/widgets/check_box_widget.dart';
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
 import 'package:polkadex/common/utils/colors.dart';
 import 'package:polkadex/common/utils/enums.dart';
@@ -13,7 +12,6 @@ import 'package:polkadex/common/utils/extensions.dart';
 import 'package:polkadex/common/utils/styles.dart';
 import 'package:polkadex/features/landing/presentation/widgets/balance_item_shimmer_widget.dart';
 import 'package:polkadex/features/landing/presentation/widgets/balance_item_widget.dart';
-import 'package:polkadex/features/landing/presentation/widgets/top_balance_widget.dart';
 import 'package:polkadex/features/landing/utils/token_utils.dart';
 import 'package:polkadex/common/widgets/chart/_app_line_chart_widget.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
@@ -72,10 +70,7 @@ class _BalanceTabViewState extends State<BalanceTabView>
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      SizedBox(height: 24),
-                      TopBalanceWidget(),
-                      SizedBox(height: 24),
-                      _ThisHoldingWidget(),
+                      _buildSelectToken(),
                       InkWell(
                         onTap: () {
                           final summaryVisProvider =
@@ -92,7 +87,7 @@ class _BalanceTabViewState extends State<BalanceTabView>
                           child: Column(
                             children: [
                               Text(
-                                'Summary',
+                                'Summary of Trades',
                                 style: tsS18W600CFF,
                                 textAlign: TextAlign.center,
                               ),
@@ -206,101 +201,6 @@ class _BalanceTabViewState extends State<BalanceTabView>
                                 width: 51,
                               ),
                             ),
-                            Center(
-                              child: SizedBox(
-                                height: 35,
-                                child: DropdownButton<String>(
-                                  items: ['Main Wallet', 'Spot', 'Margin']
-                                      .map((e) => DropdownMenuItem<String>(
-                                            child: Text(
-                                              e,
-                                              style: tsS20W600CFF,
-                                            ),
-                                            value: e,
-                                          ))
-                                      .toList(),
-                                  value: 'Main Wallet',
-                                  style: tsS20W600CFF,
-                                  underline: Container(),
-                                  onChanged: (value) {},
-                                  isExpanded: false,
-                                  icon: Icon(
-                                    Icons.keyboard_arrow_down_rounded,
-                                    color: AppColors.colorFFFFFF,
-                                    size: 16,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                top: 10,
-                                bottom: 12,
-                                left: 10,
-                                right: 10,
-                              ),
-                              child: Row(
-                                children: [
-                                  Consumer<_ThisProvider>(
-                                    builder: (context, thisProvider, child) =>
-                                        CheckBoxWidget(
-                                      checkColor: AppColors.colorFFFFFF,
-                                      backgroundColor: AppColors.colorE6007A,
-                                      isChecked:
-                                          thisProvider.isHideSmallBalance,
-                                      isBackTransparentOnUnchecked: true,
-                                      onTap: (val) =>
-                                          thisProvider.isHideSmallBalance = val,
-                                    ),
-                                  ),
-                                  SizedBox(width: 8),
-                                  Text(
-                                    'Hide small balances',
-                                    style: tsS14W400CFF,
-                                  ),
-                                  Spacer(),
-                                  InkWell(
-                                    child: Padding(
-                                      padding: const EdgeInsets.fromLTRB(
-                                          12, 12, 6, 12),
-                                      child: Opacity(
-                                        opacity: 1.0,
-                                        child: Text(
-                                          'Tokens',
-                                          style: tsS15W600CFF,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  InkWell(
-                                    onTap: () {
-                                      final thisProvider =
-                                          context.read<_ThisProvider>();
-                                      thisProvider.isHideFiat =
-                                          !thisProvider.isHideFiat;
-                                    },
-                                    child: Padding(
-                                      padding: const EdgeInsets.fromLTRB(
-                                          6, 12, 12, 12),
-                                      child: Consumer<_ThisProvider>(
-                                        builder:
-                                            (context, thisProvider, child) =>
-                                                Opacity(
-                                          opacity: thisProvider.isHideFiat
-                                              ? 1.0
-                                              : 0.3,
-                                          child: child,
-                                        ),
-                                        child: Text(
-                                          'Fiat',
-                                          style: tsS15W600CFF,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
                           ],
                         ),
                       ),
@@ -360,97 +260,73 @@ class _BalanceTabViewState extends State<BalanceTabView>
     context.read<HomeScrollNotifProvider>().scrollOffset =
         _scrollController.offset;
   }
-}
 
-/// The holding row widget handles the click event for graph
-class _ThisHoldingWidget extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildSelectToken() {
     return Padding(
-      padding: const EdgeInsets.only(
-        left: 21,
-        right: 21,
-      ),
-      child: Row(
-        children: [
-          Text(
-            'Holding: ',
-            style: tsS13W500CFF.copyWith(
-              color: AppColors.colorABB2BC,
-            ),
+      padding: EdgeInsets.all(12),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.all(
+            Radius.circular(15),
           ),
-          DropdownButton<String>(
-            items: ['24 hour', '1 week', '1 month']
-                .map((e) => DropdownMenuItem<String>(
-                      child: Text(
-                        e,
-                        style: tsS13W500CFF,
-                      ),
-                      value: e,
-                    ))
-                .toList(),
-            value: '24 hour',
-            style: tsS13W500CFF,
-            underline: Container(),
-            onChanged: (value) {},
-            isExpanded: false,
-            icon: Icon(
-              Icons.keyboard_arrow_down_rounded,
-              color: AppColors.colorFFFFFF,
-              size: 16,
-            ),
-          ),
-          // Text(
-          //   '24 hour ',
-          //   style: tsS13W500CFF,
-          // ),
-          Spacer(),
-          Text(
-            'Change ',
-            style: tsS13W500CFF.copyWith(
-              color: AppColors.colorABB2BC,
-            ),
-          ),
-          Text(
-            '+\$224',
-            style: tsS13W500CFF,
-          ),
-          Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(5),
-              color: AppColors.color0CA564,
-            ),
-            margin: const EdgeInsets.only(left: 8),
-            padding: const EdgeInsets.symmetric(
-              horizontal: 4.5,
-              vertical: 2.5,
-            ),
-            child: Row(
-              children: [
-                SvgPicture.asset(
-                  'gain_graph'.asAssetSvg(),
-                  width: 8,
-                  height: 8,
-                ),
-                SizedBox(width: 2),
-                RichText(
-                  text: TextSpan(
-                    children: <TextSpan>[
-                      TextSpan(
-                        text: '52.47',
-                        style: tsS11W600CFF,
-                      ),
-                      TextSpan(
-                        text: '%',
-                        style: tsS8W600CFF,
-                      ),
-                    ],
+        ),
+        padding: EdgeInsets.all(8),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            BlocBuilder<MarketAssetCubit, MarketAssetState>(
+              builder: (context, state) => Container(
+                child: Container(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                  ),
+                  child: Image.asset(
+                    TokenUtils.tokenIdToAssetImg(context
+                        .read<MarketAssetCubit>()
+                        .currentBaseAssetDetails
+                        .assetId),
+                    width: 50,
+                    height: 50,
+                    fit: BoxFit.contain,
                   ),
                 ),
-              ],
+              ),
             ),
-          ),
-        ],
+            Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: BlocBuilder<MarketAssetCubit, MarketAssetState>(
+                builder: (context, state) => Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${context.read<MarketAssetCubit>().currentBaseAssetDetails.symbol}/${context.read<MarketAssetCubit>().currentQuoteAssetDetails.symbol}',
+                      style: tsS20W600CFF.copyWith(color: Colors.black),
+                    ),
+                    Text(
+                      context
+                          .read<MarketAssetCubit>()
+                          .currentBaseAssetDetails
+                          .name,
+                      style:
+                          tsS14W400CFF.copyWith(color: AppColors.color1F1F1F),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  color: Colors.black,
+                  size: 16,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -296,8 +296,10 @@ class _BalanceTabViewState extends State<BalanceTabView>
                   child: PolkadexErrorRefreshWidget(
                     onRefresh: () =>
                         context.read<TradeHistoryCubit>().getAccountTrades(
-                              asset,
-                              context.read<AccountCubit>().mainAccountAddress,
+                              asset: asset,
+                              address: context
+                                  .read<AccountCubit>()
+                                  .mainAccountAddress,
                             ),
                   ),
                 );
@@ -420,8 +422,8 @@ class _BalanceTabViewState extends State<BalanceTabView>
             onChanged: (selectedAsset) {
               if (selectedAsset != null) {
                 context.read<TradeHistoryCubit>().getAccountTrades(
-                      selectedAsset,
-                      context.read<AccountCubit>().mainAccountAddress,
+                      asset: selectedAsset,
+                      address: context.read<AccountCubit>().mainAccountAddress,
                     );
               }
             },

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:polkadex/common/configs/app_config.dart';
 import 'package:polkadex/common/dummy_providers/balance_chart_dummy_provider.dart';
+import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
@@ -262,70 +263,68 @@ class _BalanceTabViewState extends State<BalanceTabView>
   }
 
   Widget _buildSelectToken() {
+    final availableAssets = context.read<MarketAssetCubit>().mapAvailableAssets;
+
     return Padding(
-      padding: EdgeInsets.all(12),
-      child: Container(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.all(
-            Radius.circular(15),
+      padding: EdgeInsets.all(6),
+      child: Padding(
+        padding: EdgeInsets.all(12),
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.all(
+              Radius.circular(15),
+            ),
           ),
-        ),
-        padding: EdgeInsets.all(8),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            BlocBuilder<MarketAssetCubit, MarketAssetState>(
-              builder: (context, state) => Container(
-                child: Container(
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                  ),
-                  child: Image.asset(
-                    TokenUtils.tokenIdToAssetImg(context
-                        .read<MarketAssetCubit>()
-                        .currentBaseAssetDetails
-                        .assetId),
-                    width: 50,
-                    height: 50,
-                    fit: BoxFit.contain,
-                  ),
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(left: 8),
-              child: BlocBuilder<MarketAssetCubit, MarketAssetState>(
-                builder: (context, state) => Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '${context.read<MarketAssetCubit>().currentBaseAssetDetails.symbol}/${context.read<MarketAssetCubit>().currentQuoteAssetDetails.symbol}',
-                      style: tsS20W600CFF.copyWith(color: Colors.black),
+          padding: EdgeInsets.all(8),
+          child: DropdownButton<AssetEntity>(
+            items: availableAssets.values
+                .map(
+                  (asset) => DropdownMenuItem<AssetEntity>(
+                    child: Container(
+                      padding: const EdgeInsets.only(bottom: 6),
+                      child: Row(
+                        children: [
+                          Image.asset(
+                            TokenUtils.tokenIdToAssetImg(asset.assetId),
+                            width: 50,
+                            height: 50,
+                            fit: BoxFit.contain,
+                          ),
+                          SizedBox(width: 8),
+                          RichText(
+                            text: TextSpan(
+                              style: tsS20W400CFF.copyWith(color: Colors.black),
+                              children: <TextSpan>[
+                                TextSpan(
+                                  text: asset.name,
+                                ),
+                                TextSpan(
+                                    text: ' (${asset.symbol})',
+                                    style: tsS20W600CFF.copyWith(
+                                        color: Colors.black)),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
-                    Text(
-                      context
-                          .read<MarketAssetCubit>()
-                          .currentBaseAssetDetails
-                          .name,
-                      style:
-                          tsS14W400CFF.copyWith(color: AppColors.color1F1F1F),
-                    ),
-                  ],
-                ),
-              ),
+                    value: asset,
+                  ),
+                )
+                .toList(),
+            value: availableAssets.values.first,
+            style: tsS16W600CFF,
+            dropdownColor: Colors.white,
+            underline: Container(),
+            onChanged: (value) {},
+            isExpanded: true,
+            icon: Icon(
+              Icons.keyboard_arrow_down_rounded,
+              color: Colors.black,
+              size: 16,
             ),
-            Expanded(
-              child: Align(
-                alignment: Alignment.centerRight,
-                child: Icon(
-                  Icons.keyboard_arrow_down_rounded,
-                  color: Colors.black,
-                  size: 16,
-                ),
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:polkadex/common/configs/app_config.dart';
+import 'package:intl/intl.dart';
 import 'package:polkadex/common/dummy_providers/balance_chart_dummy_provider.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
-import 'package:polkadex/common/navigation/coordinator.dart';
 import 'package:polkadex/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
+import 'package:polkadex/features/coin/presentation/widgets/order_history_shimmer_widget.dart';
+import 'package:polkadex/features/landing/presentation/widgets/trade_item_widget.dart';
 import 'package:polkadex/common/utils/colors.dart';
-import 'package:polkadex/common/utils/enums.dart';
-import 'package:polkadex/common/utils/extensions.dart';
 import 'package:polkadex/common/utils/styles.dart';
+import 'package:polkadex/common/navigation/coordinator.dart';
+import 'package:polkadex/common/widgets/build_methods.dart';
 import 'package:polkadex/features/landing/utils/token_utils.dart';
-import 'package:polkadex/common/widgets/chart/_app_line_chart_widget.dart';
+import 'package:polkadex/common/widgets/polkadex_progress_error_widget.dart';
 import 'package:polkadex/common/cubits/account_cubit/account_cubit.dart';
 import 'package:provider/provider.dart';
 
@@ -71,6 +71,7 @@ class _BalanceTabViewState extends State<BalanceTabView>
                     children: [
                       _buildSelectTokenWidget(assetEntity: state.assetSelected),
                       _buildBalanceWidget(),
+                      SizedBox(height: 12),
                       InkWell(
                         onTap: () {
                           final summaryVisProvider =
@@ -82,140 +83,134 @@ class _BalanceTabViewState extends State<BalanceTabView>
 
                           summaryVisProvider.toggleVisible();
                         },
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8.0),
-                          child: Column(
-                            children: [
-                              Text(
-                                'Summary of Trades',
-                                style: tsS18W600CFF,
-                                textAlign: TextAlign.center,
-                              ),
-                              RotationTransition(
-                                turns: Tween(begin: 0.0, end: 0.5)
-                                    .animate(_controller),
-                                child: Icon(
-                                  Icons.keyboard_arrow_down_rounded,
-                                  color: AppColors.colorFFFFFF,
-                                  size: 16,
+                        child: state.assetSelected != null
+                            ? Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 8),
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      'Summary of Trades',
+                                      style: tsS18W600CFF,
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ],
                                 ),
                               )
-                            ],
-                          ),
-                        ),
-                      ),
-                      Consumer<_ThisIsChartVisibleProvider>(
-                        builder: (context, isChartVisbileProvider, _) =>
-                            AnimatedSize(
-                          duration: AppConfigs.animDurationSmall,
-                          alignment: Alignment.topCenter,
-                          child: isChartVisbileProvider.isChartVisible
-                              ? Column(
-                                  children: [
-                                    _ThisGraphHeadingWidget(),
-                                    SizedBox(height: 8),
-                                    SizedBox(
-                                      height: 250,
-                                      child:
-                                          Consumer<BalanceChartDummyProvider>(
-                                        builder: (context, provider, child) =>
-                                            AppLineChartWidget(
-                                          data: provider.list,
-                                          options: AppLineChartOptions(
-                                            yLabelCount: 3,
-                                            yAxisTopPaddingRatio: 0.05,
-                                            yAxisBottomPaddingRatio: 0.15,
-                                            chartScale: provider.chartScale,
-                                            lineColor: AppColors.colorE6007A,
-                                            yAxisLabelPrefix: "\$ ",
-                                            areaGradient: LinearGradient(
-                                              begin: Alignment.topCenter,
-                                              end: Alignment.bottomCenter,
-                                              colors: <Color>[
-                                                AppColors.colorE6007A
-                                                    .withOpacity(0.50),
-                                                AppColors.color8BA1BE
-                                                    .withOpacity(0.0),
-                                              ],
-                                              // stops: [0.0, 0.40],
-                                            ),
-                                            gridColor: AppColors.color8BA1BE
-                                                .withOpacity(0.15),
-                                            gridStroke: 1,
-                                            yLabelTextStyle: TextStyle(
-                                              fontSize: 08,
-                                              fontFamily: "WorkSans",
-                                              fontWeight: FontWeight.w400,
-                                              color: Colors.grey.shade400,
-                                            ),
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                    _ThisGraphOptionWidget(),
-                                    SizedBox(height: 30),
-                                  ],
-                                )
-                              : Container(),
-                        ),
+                            : Container(),
                       ),
                     ],
                   ),
                 ),
               ];
             },
-            body: Container(
-              clipBehavior: Clip.antiAlias,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(40),
-                color: AppColors.color2E303C,
-                boxShadow: <BoxShadow>[
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    blurRadius: 30,
-                    offset: Offset(0.0, 20.0),
-                  ),
-                ],
-              ),
-              padding: const EdgeInsets.fromLTRB(12.5, 19.0, 12.5, 0.0),
-              child: CustomScrollView(
-                slivers: [
-                  SliverPersistentHeader(
-                    floating: false,
-                    pinned: true,
-                    delegate: _SliverPersistentHeaderDelegate(
-                      height: 115,
-                      child: Container(
-                        color: AppColors.color2E303C,
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            Center(
-                              child: Container(
-                                margin: const EdgeInsets.only(bottom: 13),
-                                decoration: BoxDecoration(
-                                  color: AppColors.color1C2023,
-                                  borderRadius: BorderRadius.circular(10),
-                                ),
-                                height: 3,
-                                width: 51,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                  SliverToBoxAdapter(
-                    child: Container(),
-                  ),
-                ],
-              ),
-            ),
+            body: state.assetSelected != null
+                ? _buildTradeList(asset: state.assetSelected!)
+                : Container(),
           );
         },
       ),
     );
+  }
+
+  Widget _buildTradeList({required AssetEntity asset}) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Container(
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(40),
+            color: AppColors.color2E303C,
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: Colors.black.withOpacity(0.1),
+                blurRadius: 30,
+                offset: Offset(0.0, 20.0),
+              ),
+            ],
+          ),
+          padding: const EdgeInsets.fromLTRB(12.5, 19.0, 12.5, 0.0),
+          child: BlocBuilder<TradeHistoryCubit, TradeHistoryState>(
+            builder: (context, state) {
+              if (state is TradeHistoryLoaded) {
+                return state.trades.isEmpty
+                    ? Padding(
+                        padding: EdgeInsets.fromLTRB(18, 26.0, 18, 10),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Padding(
+                              padding:
+                                  const EdgeInsets.only(top: 36, bottom: 36),
+                              child: Text(
+                                "There are no transactions",
+                                style: tsS16W500CABB2BC,
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    : ListView.builder(
+                        physics: NeverScrollableScrollPhysics(),
+                        shrinkWrap: true,
+                        itemCount: state.trades.length,
+                        padding: const EdgeInsets.only(top: 13),
+                        itemBuilder: (context, index) {
+                          return TradeItemWidget(
+                            tradeItem: state.trades[index],
+                            dateTitle: _getDateTitle(
+                                state.trades[index].time,
+                                index > 0
+                                    ? state.trades[index - 1].time
+                                    : null),
+                          );
+                        },
+                      );
+              }
+
+              if (state is TradeHistoryError) {
+                return Container(
+                  height: 50,
+                  child: PolkadexErrorRefreshWidget(
+                    onRefresh: () =>
+                        context.read<TradeHistoryCubit>().getAccountTrades(
+                              asset,
+                              context.read<AccountCubit>().mainAccountAddress,
+                            ),
+                  ),
+                );
+              }
+
+              return OrderHistoryShimmerWidget();
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  String? _getDateTitle(DateTime date, DateTime? previousDate) {
+    final dateString = _getDateString(date);
+    final datePreviousString =
+        previousDate != null ? _getDateString(previousDate) : '';
+
+    return dateString != datePreviousString ? dateString : null;
+  }
+
+  String _getDateString(DateTime date) {
+    final today = DateTime.now();
+    if (date.day == today.day &&
+        date.month == today.month &&
+        date.year == today.year) {
+      return "Today";
+    } else if (date.day == today.day - 1 &&
+        date.month == today.month &&
+        date.year == today.year) {
+      return "Yesterday";
+    } else {
+      return DateFormat("dd MMMM, yyyy").format(date);
+    }
   }
 
   void _onScrollListener() {
@@ -294,133 +289,52 @@ class _BalanceTabViewState extends State<BalanceTabView>
           state is BalanceLoaded && selectedAsset != null
               ? Padding(
                   padding: EdgeInsets.all(6),
-                  child: Padding(
-                    padding: EdgeInsets.all(12),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceAround,
-                      children: [
-                        Text(
-                          'Free: ${state.free[selectedAsset.assetId]}',
-                          style: tsS16W600CFF,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.all(12),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          children: [
+                            Text(
+                              'Free: ${state.free[selectedAsset.assetId]}',
+                              style: tsS16W600CFF,
+                            ),
+                            Text(
+                              'Reserved: ${state.reserved[selectedAsset.assetId]}',
+                              style: tsS16W600CFF,
+                            ),
+                          ],
                         ),
-                        Text(
-                          'Reserved: ${state.reserved[selectedAsset.assetId]}',
-                          style: tsS16W600CFF,
+                      ),
+                      Container(
+                        decoration: BoxDecoration(
+                          color: AppColors.colorE6007A,
+                          borderRadius: BorderRadius.circular(5),
                         ),
-                      ],
-                    ),
+                        child: buildInkWell(
+                          borderRadius: BorderRadius.circular(5),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 6,
+                              horizontal: 12,
+                            ),
+                            child: Text(
+                              "Withdraw",
+                              style: tsS14W600CFF,
+                            ),
+                          ),
+                          onTap: () => Coordinator.goToCoinWithdrawScreen(
+                            asset: selectedAsset,
+                            balanceCubit: context.read<BalanceCubit>(),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 )
               : Container(),
-    );
-  }
-}
-
-/// The heading part of the graph.
-class _ThisGraphHeadingWidget extends StatelessWidget {
-  Widget _buildItemWidget(
-      {required String? imgAsset,
-      required String title,
-      required String value}) {
-    return Row(
-      children: [
-        Container(
-          width: 23,
-          height: 23,
-          decoration: BoxDecoration(
-            color: (imgAsset == null)
-                ? AppColors.color8BA1BE.withOpacity(0.20)
-                : Colors.white,
-            borderRadius: BorderRadius.circular(8),
-          ),
-          margin: const EdgeInsets.only(right: 6),
-          padding: const EdgeInsets.all(2),
-          child: (imgAsset == null) ? null : Image.asset(imgAsset),
-        ),
-        Expanded(
-            child: Text(
-          title,
-          style: tsS13W500CFF.copyWith(color: AppColors.colorABB2BC),
-        )),
-        Text(
-          value,
-          style: tsS12W500CFF,
-        ),
-      ],
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(21, 0, 21, 0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                            flex: 5,
-                            child: _buildItemWidget(
-                                imgAsset:
-                                    'trade_open/trade_open_1.png'.asAssetImg(),
-                                title: 'BTC',
-                                value: "60%")),
-                        Spacer(),
-                        Expanded(
-                            flex: 5,
-                            child: _buildItemWidget(
-                                imgAsset:
-                                    'trade_open/trade_open_2.png'.asAssetImg(),
-                                title: 'DEX',
-                                value: "22%")),
-                        Spacer(),
-                      ],
-                    ),
-                    SizedBox(height: 7),
-                    Row(
-                      children: [
-                        Expanded(
-                            flex: 5,
-                            child: _buildItemWidget(
-                                imgAsset:
-                                    'trade_open/trade_open_3.png'.asAssetImg(),
-                                title: 'USDT',
-                                value: "10%")),
-                        Spacer(),
-                        Expanded(
-                            flex: 5,
-                            child: _buildItemWidget(
-                                imgAsset: null, title: 'Others', value: "8%")),
-                        Spacer(),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              InkWell(
-                onTap: () => Coordinator.goToBalanceSummaryScreen(),
-                child: Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: AppColors.colorE6007A,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  padding: const EdgeInsets.all(10),
-                  child: SvgPicture.asset('pie-chart-18'.asAssetSvg()),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
     );
   }
 }
@@ -439,98 +353,5 @@ class _ThisIsChartVisibleProvider extends ChangeNotifier {
   void toggleVisible() {
     _isChartVisible = !_isChartVisible;
     notifyListeners();
-  }
-}
-
-/// The bottom option menu unnder the graph
-class _ThisGraphOptionWidget extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(25, 10, 16, 14),
-      child: Wrap(
-        children: EnumBalanceChartDataTypes.values
-            .map<Widget>((item) => Consumer<BalanceChartDummyProvider>(
-                  builder: (context, appChartProvider, child) {
-                    String text;
-                    switch (item) {
-                      case EnumBalanceChartDataTypes.hour:
-                        text = "24h";
-                        break;
-                      case EnumBalanceChartDataTypes.week:
-                        text = "7d";
-                        break;
-                      case EnumBalanceChartDataTypes.month:
-                        text = "1m";
-                        break;
-                      case EnumBalanceChartDataTypes.threeMonth:
-                        text = "3m";
-
-                        break;
-                      case EnumBalanceChartDataTypes.sixMonth:
-                        text = "6m";
-                        break;
-                      case EnumBalanceChartDataTypes.year:
-                        text = "1y";
-                        break;
-                      case EnumBalanceChartDataTypes.all:
-                        text = "All";
-                        break;
-                    }
-                    return InkWell(
-                      onTap: () {
-                        appChartProvider.balanceChartDataType = item;
-                      },
-                      child: AnimatedContainer(
-                        duration: AppConfigs.animDurationSmall,
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 11.5),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: item == appChartProvider.balanceChartDataType
-                              ? AppColors.colorE6007A
-                              : null,
-                        ),
-                        child: Text(
-                          text,
-                          style: item == appChartProvider.balanceChartDataType
-                              ? tsS13W600CFF
-                              : tsS12W400CFF.copyWith(
-                                  color: AppColors.colorABB2BC),
-                        ),
-                      ),
-                    );
-                  },
-                ))
-            .toList(),
-      ),
-    );
-  }
-}
-
-/// The sliver widget to maintain the wallet heading persistent on scroll
-class _SliverPersistentHeaderDelegate extends SliverPersistentHeaderDelegate {
-  final Widget child;
-  final double height;
-
-  _SliverPersistentHeaderDelegate({
-    required this.child,
-    required this.height,
-  }) : super();
-  @override
-  Widget build(
-      BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return child;
-  }
-
-  @override
-  double get maxExtent => height;
-
-  @override
-  double get minExtent => height;
-
-  @override
-  bool shouldRebuild(covariant _SliverPersistentHeaderDelegate oldDelegate) {
-    return oldDelegate.height != height || oldDelegate.child != child;
   }
 }

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -7,6 +7,7 @@ import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
 import 'package:polkadex/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart';
+import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
 import 'package:polkadex/common/utils/colors.dart';
 import 'package:polkadex/common/utils/enums.dart';
@@ -69,6 +70,7 @@ class _BalanceTabViewState extends State<BalanceTabView>
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       _buildSelectTokenWidget(assetEntity: state.assetSelected),
+                      _buildBalanceWidget(),
                       InkWell(
                         onTap: () {
                           final summaryVisProvider =
@@ -281,6 +283,35 @@ class _BalanceTabViewState extends State<BalanceTabView>
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildBalanceWidget() {
+    final selectedAsset = context.read<TradeHistoryCubit>().state.assetSelected;
+
+    return BlocBuilder<BalanceCubit, BalanceState>(
+      builder: (context, state) =>
+          state is BalanceLoaded && selectedAsset != null
+              ? Padding(
+                  padding: EdgeInsets.all(6),
+                  child: Padding(
+                    padding: EdgeInsets.all(12),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        Text(
+                          'Free: ${state.free[selectedAsset.assetId]}',
+                          style: tsS16W600CFF,
+                        ),
+                        Text(
+                          'Reserved: ${state.reserved[selectedAsset.assetId]}',
+                          style: tsS16W600CFF,
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              : Container(),
     );
   }
 }

--- a/lib/features/landing/presentation/sub_views/balance_tab_view.dart
+++ b/lib/features/landing/presentation/sub_views/balance_tab_view.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:intl/intl.dart';
 import 'package:polkadex/common/dummy_providers/balance_chart_dummy_provider.dart';
 import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
+import 'package:polkadex/common/utils/extensions.dart';
+import 'package:polkadex/common/widgets/app_buttons.dart';
 import 'package:polkadex/features/coin/presentation/cubits/trade_history_cubit/trade_history_cubit.dart';
 import 'package:polkadex/features/landing/presentation/cubits/balance_cubit/balance_cubit.dart';
 import 'package:polkadex/features/landing/presentation/providers/home_scroll_notif_provider.dart';
@@ -12,7 +15,6 @@ import 'package:polkadex/features/landing/presentation/widgets/trade_item_widget
 import 'package:polkadex/common/utils/colors.dart';
 import 'package:polkadex/common/utils/styles.dart';
 import 'package:polkadex/common/navigation/coordinator.dart';
-import 'package:polkadex/common/widgets/build_methods.dart';
 import 'package:polkadex/features/landing/utils/token_utils.dart';
 import 'package:polkadex/common/widgets/polkadex_progress_error_widget.dart';
 import 'package:polkadex/common/cubits/account_cubit/account_cubit.dart';
@@ -308,28 +310,17 @@ class _BalanceTabViewState extends State<BalanceTabView>
                           ],
                         ),
                       ),
-                      Container(
-                        decoration: BoxDecoration(
-                          color: AppColors.colorE6007A,
-                          borderRadius: BorderRadius.circular(5),
+                      AppButton(
+                        label: 'Withdraw',
+                        leadingWidget: SvgPicture.asset(
+                          'Withdraw'.asAssetSvg(),
                         ),
-                        child: buildInkWell(
-                          borderRadius: BorderRadius.circular(5),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              vertical: 6,
-                              horizontal: 12,
-                            ),
-                            child: Text(
-                              "Withdraw",
-                              style: tsS14W600CFF,
-                            ),
-                          ),
-                          onTap: () => Coordinator.goToCoinWithdrawScreen(
-                            asset: selectedAsset,
-                            balanceCubit: context.read<BalanceCubit>(),
-                          ),
+                        backgroundColor: AppColors.color3B4150,
+                        onTap: () => Coordinator.goToCoinWithdrawScreen(
+                          asset: selectedAsset,
+                          balanceCubit: context.read<BalanceCubit>(),
                         ),
+                        outerPadding: EdgeInsets.only(top: 8),
                       ),
                     ],
                   ),

--- a/lib/features/landing/presentation/widgets/trade_item_widget.dart
+++ b/lib/features/landing/presentation/widgets/trade_item_widget.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:intl/intl.dart';
+import 'package:polkadex/common/utils/enums.dart';
+import 'package:polkadex/common/utils/colors.dart';
+import 'package:polkadex/common/utils/extensions.dart';
+import 'package:polkadex/common/utils/styles.dart';
+import 'package:polkadex/common/trades/domain/entities/account_trade_entity.dart';
+import 'package:polkadex/common/market_asset/presentation/cubit/market_asset_cubit.dart';
+
+class TradeItemWidget extends StatelessWidget {
+  const TradeItemWidget({
+    required this.tradeItem,
+    required this.dateTitle,
+  });
+
+  final AccountTradeEntity tradeItem;
+  final String? dateTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = Container();
+
+    switch (tradeItem.txnType) {
+      case EnumTradeTypes.deposit:
+      case EnumTradeTypes.withdraw:
+        child = _buildHistoryTradeItemWidget(context, tradeItem);
+        break;
+      default:
+        child = Container();
+    }
+
+    final cardWidget = Padding(
+      padding: const EdgeInsets.only(bottom: 14),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(15),
+        ),
+        padding: const EdgeInsets.fromLTRB(14, 17, 14, 17),
+        child: child,
+      ),
+    );
+
+    if (dateTitle?.isNotEmpty ?? false) {
+      final double topPadding =
+          ['Today', 'Yesterday'].contains(dateTitle) ? 7.0 : 26.0;
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(18, topPadding, 18, 10),
+            child: Text(
+              dateTitle ?? "",
+              style: tsS16W500CFF,
+            ),
+          ),
+          cardWidget,
+        ],
+      );
+    }
+
+    return cardWidget;
+  }
+
+  Widget _buildHistoryTradeItemWidget(
+      BuildContext context, AccountTradeEntity trade) {
+    final cubit = context.read<MarketAssetCubit>();
+    Widget mainIcon;
+
+    switch (trade.txnType) {
+      case EnumTradeTypes.deposit:
+        mainIcon = SvgPicture.asset(
+          'Deposit'.asAssetSvg(),
+        );
+        break;
+      case EnumTradeTypes.withdraw:
+        mainIcon = SvgPicture.asset(
+          'Withdraw'.asAssetSvg(),
+        );
+        break;
+      default:
+        mainIcon = Container();
+    }
+
+    return Row(
+      children: [
+        Container(
+          width: 47,
+          height: 47,
+          margin: const EdgeInsets.only(right: 4.2),
+          padding: const EdgeInsets.symmetric(vertical: 7.0, horizontal: 13),
+          decoration: BoxDecoration(
+              color: AppColors.color8BA1BE.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(12)),
+          child: mainIcon,
+        ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                cubit.getAssetDetailsById(trade.asset).symbol,
+                style: tsS15W500CFF,
+              ),
+              SizedBox(height: 1),
+              Text(
+                DateFormat("hh:mm:ss aa").format(trade.time).toUpperCase(),
+                style: tsS13W400CFFOP60.copyWith(color: AppColors.colorABB2BC),
+              ),
+            ],
+          ),
+        ),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Row(
+              children: [
+                Text(
+                  '${trade.amount} ${cubit.getAssetDetailsById(trade.asset).symbol}',
+                  style: tsS14W500CFF.copyWith(
+                    color: trade.txnType == EnumTradeTypes.deposit
+                        ? AppColors.color0CA564
+                        : AppColors.colorE6007A,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/coin/presentation/trade_history_cubit_test.dart
+++ b/test/features/coin/presentation/trade_history_cubit_test.dart
@@ -1,6 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:dartz/dartz.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:polkadex/common/market_asset/data/models/asset_model.dart';
+import 'package:polkadex/common/market_asset/domain/entities/asset_entity.dart';
 import 'package:polkadex/common/network/error.dart';
 import 'package:polkadex/common/trades/data/models/account_trade_model.dart';
 import 'package:polkadex/common/trades/domain/entities/account_trade_entity.dart';
@@ -21,13 +23,14 @@ void main() {
   late _MockGetAccountTradesUpdatesUseCase _mockGetAccountTradesUpdatesUseCase;
   late TradeHistoryCubit cubit;
   late String mainAccount;
-  late String asset;
+  late String assetId;
   late DateTime time;
   late String status;
   late String amount;
   late String fee;
   late String address;
   late AccountTradeEntity trade;
+  late AssetEntity asset;
 
   setUp(() {
     _mockGetAccountTradesUsecase = _MockGetAccountTradesUsecase();
@@ -38,7 +41,7 @@ void main() {
         getAccountTradesUpdatesUseCase: _mockGetAccountTradesUpdatesUseCase);
 
     mainAccount = '786653432';
-    asset = "0";
+    assetId = "0";
     time = DateTime.fromMillisecondsSinceEpoch(1644853305519);
     status = 'OPEN';
     amount = "100.0";
@@ -47,11 +50,19 @@ void main() {
     trade = AccountTradeModel(
       mainAccount: mainAccount,
       txnType: EnumTradeTypes.deposit,
-      asset: asset,
+      asset: assetId,
       amount: amount,
       fee: fee,
       status: status,
       time: time,
+    );
+    asset = AssetModel(
+      assetId: assetId,
+      deposit: '',
+      name: 'asset',
+      symbol: 'ASS',
+      decimals: '22',
+      isFrozen: false,
     );
   });
 
@@ -88,7 +99,7 @@ void main() {
         },
         act: (cubit) async {
           await cubit.getAccountTrades(
-            '0',
+            asset,
             address,
           );
         },
@@ -124,7 +135,7 @@ void main() {
         },
         act: (cubit) async {
           await cubit.getAccountTrades(
-            '0',
+            asset,
             address,
           );
         },

--- a/test/features/coin/presentation/trade_history_cubit_test.dart
+++ b/test/features/coin/presentation/trade_history_cubit_test.dart
@@ -104,8 +104,13 @@ void main() {
           );
         },
         expect: () => [
-          TradeHistoryLoading(),
-          TradeHistoryLoaded(trades: [trade]),
+          TradeHistoryLoading(
+            assetSelected: asset,
+          ),
+          TradeHistoryLoaded(
+            assetSelected: asset,
+            trades: [trade],
+          ),
         ],
       );
 
@@ -140,8 +145,13 @@ void main() {
           );
         },
         expect: () => [
-          TradeHistoryLoading(),
-          TradeHistoryError(message: 'error'),
+          TradeHistoryLoading(
+            assetSelected: asset,
+          ),
+          TradeHistoryError(
+            assetSelected: asset,
+            message: 'error',
+          ),
         ],
       );
     },

--- a/test/features/coin/presentation/trade_history_cubit_test.dart
+++ b/test/features/coin/presentation/trade_history_cubit_test.dart
@@ -99,8 +99,8 @@ void main() {
         },
         act: (cubit) async {
           await cubit.getAccountTrades(
-            asset,
-            address,
+            asset: asset,
+            address: address,
           );
         },
         expect: () => [
@@ -140,8 +140,8 @@ void main() {
         },
         act: (cubit) async {
           await cubit.getAccountTrades(
-            asset,
-            address,
+            asset: asset,
+            address: address,
           );
         },
         expect: () => [


### PR DESCRIPTION
This PR heavily changes the balance view from the mobile app. It should resemble the equivalent screen on the mobile app since it now lets you select the asset and ashows the free and reserved balance, trades and a withdraw button.

Closes #184 