### PR TITLE
Fix/inverted color depth orderbook

### DIFF
--- a/lib/common/orderbook/data/models/orderbook_model.dart
+++ b/lib/common/orderbook/data/models/orderbook_model.dart
@@ -37,8 +37,8 @@ class OrderbookModel extends OrderbookEntity {
       },
     ).toList();
 
-    dataAsk.sort((a, b) => a.price.compareTo(b.price));
-    dataBid.sort((a, b) => a.price.compareTo(b.price));
+    dataAsk.sort((a, b) => b.price.compareTo(a.price));
+    dataBid.sort((a, b) => b.price.compareTo(a.price));
 
     return OrderbookModel(
       ask: dataAsk,

--- a/lib/common/orderbook/presentation/widgets/order_book_widget.dart
+++ b/lib/common/orderbook/presentation/widgets/order_book_widget.dart
@@ -165,7 +165,7 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
           ConstrainedBox(
             constraints: BoxConstraints(minHeight: 430),
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: columnChildren,
             ),
           )
@@ -175,7 +175,10 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
   }
 
   Widget _buildSellWidget(List<OrderbookItemEntity> sellItems) {
-    List<double> cumulativeAmount = _buildCumulativeAmountList(sellItems);
+    List<double> cumulativeAmount = _buildCumulativeAmountList(
+      items: sellItems,
+      isAscendingOrder: false,
+    );
 
     return Padding(
       padding: EdgeInsets.only(left: 8),
@@ -186,7 +189,7 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
             (index) => OrderSellItemWidget(
                   orderbookItem: sellItems[index],
                   percentageFilled:
-                      cumulativeAmount[index] / cumulativeAmount.last,
+                      cumulativeAmount[index] / cumulativeAmount.first,
                   marketDropDownNotifier: marketDropDownNotifier,
                   priceLengthNotifier: priceLengthNotifier,
                 )),
@@ -195,7 +198,7 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
   }
 
   Widget _buildBuyWidget(List<OrderbookItemEntity> buyItems) {
-    List<double> cumulativeAmount = _buildCumulativeAmountList(buyItems);
+    List<double> cumulativeAmount = _buildCumulativeAmountList(items: buyItems);
 
     return Padding(
       padding: EdgeInsets.only(left: 8),
@@ -214,18 +217,35 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
     );
   }
 
-  List<double> _buildCumulativeAmountList(List<OrderbookItemEntity> items) {
+  List<double> _buildCumulativeAmountList({
+    required List<OrderbookItemEntity> items,
+    bool isAscendingOrder = true,
+  }) {
     final List<double> cumulativeAmount = [];
 
-    for (var i = 0; i < items.length; i++) {
-      if (i == 0) {
-        cumulativeAmount.add(items[i].amount);
-      } else {
-        cumulativeAmount.add(cumulativeAmount[i - 1] + items[i].amount);
+    if (isAscendingOrder) {
+      for (var i = 0; i < items.length; i++) {
+        if (i == 0) {
+          cumulativeAmount.add((items[i].amount * items[i].price));
+        } else {
+          cumulativeAmount
+              .add(cumulativeAmount.last + (items[i].amount * items[i].price));
+        }
       }
-    }
 
-    return cumulativeAmount;
+      return cumulativeAmount;
+    } else {
+      for (var i = items.length - 1; i >= 0; i--) {
+        if (i == items.length - 1) {
+          cumulativeAmount.add((items[i].amount * items[i].price));
+        } else {
+          cumulativeAmount
+              .add(cumulativeAmount.last + (items[i].amount * items[i].price));
+        }
+      }
+
+      return cumulativeAmount.reversed.toList();
+    }
   }
 
   Widget _buildHeadingWidget() {

--- a/lib/common/orderbook/presentation/widgets/order_book_widget.dart
+++ b/lib/common/orderbook/presentation/widgets/order_book_widget.dart
@@ -37,7 +37,10 @@ class OrderBookWidget extends StatelessWidget {
           return Column(
             children: [
               Padding(
-                padding: const EdgeInsets.only(left: 8),
+                padding: const EdgeInsets.only(
+                  left: 8,
+                  bottom: 8,
+                ),
                 child: OrderBookHeadingWidget(
                   marketDropDownNotifier: marketDropDownNotifier,
                   priceLengthNotifier: priceLengthNotifier,
@@ -151,6 +154,7 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
         columnChildren = [
           _buildSellWidget(sellItems),
           _buildLatestTransactionWidget(),
+          _buildHeadingWidget(),
           _buildBuyWidget(buyItems),
         ];
         break;
@@ -257,7 +261,6 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
     return Padding(
       padding: EdgeInsets.only(
         left: 8,
-        top: 16,
         bottom: 10,
       ),
       child: Row(

--- a/lib/common/orderbook/presentation/widgets/order_book_widget.dart
+++ b/lib/common/orderbook/presentation/widgets/order_book_widget.dart
@@ -165,7 +165,7 @@ class _ThisOrderBookChartWidget extends StatelessWidget {
           ConstrainedBox(
             constraints: BoxConstraints(minHeight: 430),
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: columnChildren,
             ),
           )

--- a/lib/common/orderbook/presentation/widgets/order_buy_item_widget.dart
+++ b/lib/common/orderbook/presentation/widgets/order_buy_item_widget.dart
@@ -22,7 +22,7 @@ class OrderBuyItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return OrderBookChartItemWidget(
       percentage: percentageFilled,
-      direction: EnumGradientDirection.right,
+      direction: EnumGradientDirection.left,
       color: AppColors.color0CA564,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(0.0, 6, 6, 6),


### PR DESCRIPTION
This PR fixes the inverted color depth based on the cumulative amount. Fixed to other minor issues related to the orderbook widget are also in this PR.

Closes #186 

![Captura de tela 2022-08-31 163725](https://user-images.githubusercontent.com/38893955/187768042-dfba0667-6a7c-4398-875d-26dd874bed2e.jpg)

