### PR TITLE
fix: makes the trade view as the inital page after the user signs up/in

### DIFF
--- a/lib/features/landing/presentation/screens/landing_screen.dart
+++ b/lib/features/landing/presentation/screens/landing_screen.dart
@@ -42,7 +42,7 @@ class _LandingScreenState extends State<LandingScreen>
 
   late ScrollController _scrollController;
 
-  final ValueNotifier<int> _pageViewNotifier = ValueNotifier<int>(0);
+  final ValueNotifier<int> _pageViewNotifier = ValueNotifier<int>(2);
 
   final LoadingOverlay _loadingOverlay = LoadingOverlay();
 
@@ -67,7 +67,7 @@ class _LandingScreenState extends State<LandingScreen>
       reverseDuration: AppConfigs.animDurationSmall,
     );
 
-    _pageController = PageController();
+    _pageController = PageController(initialPage: 2);
 
     _scrollController = ScrollController();
 


### PR DESCRIPTION
This PR changes the lading screen so that the trade view is shown to the use after sign up/in.

Closes #220 


https://user-images.githubusercontent.com/38893955/188235065-cd4406c2-1e98-4311-a16d-641aacf1b46b.mp4

